### PR TITLE
scramble preamble

### DIFF
--- a/app/src/main/cpp/decoder.hh
+++ b/app/src/main/cpp/decoder.hh
@@ -143,6 +143,9 @@ class Decoder {
 			cons[i] = demod_or_erase(freq[first_subcarrier + i], cons[i]);
 		for (int i = 0; i < subcarrier_count; ++i)
 			mod_soft(meta + mod_bits * i, cons[i], 8);
+		CODE::MLS seq(0b10000011);
+		for (int i = 0; i < meta_len; ++i)
+			meta[i] *= nrz(seq());
 		return hadamard(meta);
 	}
 

--- a/app/src/main/cpp/encoder.hh
+++ b/app/src/main/cpp/encoder.hh
@@ -75,6 +75,9 @@ class Encoder {
 
 	void preamble(int data) {
 		hadamard(meta, data);
+		CODE::MLS seq(0b10000011);
+		for (int i = 0; i < meta_len; ++i)
+			meta[i] *= nrz(seq());
 		for (int i = 0; i < subcarrier_count; ++i)
 			freq[first_subcarrier + i] *= mod_map(meta + mod_bits * i);
 		symbol();


### PR DESCRIPTION
We need to scramble the preamble, otherwise some codes cause problems with the detection of the sync symbol.
This of course breaks compatibility with previously encoded signals.
The modem code in the ribbit branch here has been already updated:
https://github.com/aicodix/modem/tree/ribbit
I will also update the signal in the YouTube video here:
https://www.youtube.com/shorts/gLNuVAGtLVA